### PR TITLE
Embed MarkdownAST

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ The resulting HTML for the above markdown would look something like this:
 
 ```html
 <h1>Sample Markdown</h1>
-<div class="markdown-fragment">
-  <h2>This is an example of an embedded markdown fragment.</h2>
-</div>
+<h2>This is an example of an embedded markdown fragment.</h2>
 ```
 
 ## Installation

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ const normalizePath = require("normalize-path");
 const visit = require("unist-util-visit");
 const unified = require('unified');
 const parse = require('remark-parse');
-const html = require('remark-html');
 
 module.exports = function (_ref, _temp) {
   var markdownAST = _ref.markdownAST;
@@ -35,13 +34,13 @@ module.exports = function (_ref, _temp) {
         throw Error(`Invalid fragment specified; no such file "${ path }"`);
       }
 
-      const code = fs.readFileSync(path, "utf8");
-
-      const markdown = unified().use(parse).use(html);
-
       try {
-        node.value = `<div class=\"markdown-fragment\">${ markdown.processSync(code) }</div>`;
-        node.type = "html";
+        const embedMarkdownAST = unified().use(parse).parse(fs.readFileSync(path, "utf8"));
+
+        // Reset this node to instead of containing the "inlineCode" pointing to the embedded Markdown nodes as children
+        node.type = "parent";
+        node.children = [embedMarkdownAST];
+        delete node.value;
       } catch (e) {
         throw Error(`${ e.message } \nFile: ${ file }`);
       }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "babel-preset-gatsby-package": "^0.1.3",
     "cross-env": "^5.1.4",
     "jest": "^21.2.1",
+    "remark": "^9.0.0",
+    "remark-html": "^9.0.0",
     "react": "^16.6.3"
   },
   "dependencies": {
@@ -27,7 +29,6 @@
     "unist-util-map": "^1.0.3",
     "unist-util-visit": "^1.4.0",
     "unified": "^6.1.5",
-    "remark-html": "^9.0.0",
     "remark-parse": "^5.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-remark-embed-markdown",
   "license": "Apache-2.0",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "Jessica Stodola <jessica_stodola@comcast.com>",
   "repository": "https://github.com/jtstodola/gatsby-remark-embed-markdown",
   "keywords": [


### PR DESCRIPTION
Instead of directly transforming the embedded markdown file to HTML,
embed the AST nodes into the existing tree.
This allows other plugins such as the gatsby-remark-prismjs to correctly
transform the embedded Markdown. Otherwise these transformers won't
apply to HTML nodes.

The wrapping `div` element is dropped. Not sure if users are really relying on it for styling.

Tests are updated to verify the changes.